### PR TITLE
Sort memcache_hosts return value.

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -33,4 +33,4 @@ class MemcachedRequires(RelationBase):
         return list(set(values))
 
     def memcache_hosts(self):
-        return self.get_remote_all('private-address')
+        return sorted(self.get_remote_all('private-address'))


### PR DESCRIPTION
The list of memcache_hosts is typically rendered in a config file
template, and if restarting the service hinges on config file changes,
the fact that memcache_hosts could return the same set of values in a
different order can result in unwanted restarts.

Simply sort the return value to ensure that given the same set of
'private-address' values, the result's order will not change.